### PR TITLE
open up AS dependency to all of major version 5

### DIFF
--- a/solaredge.gemspec
+++ b/solaredge.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.1'
 
-  s.add_dependency 'activesupport', '~> 5.1.7'
+  s.add_dependency 'activesupport', '~> 5.0'
   s.add_development_dependency 'rake', '~> 10.4.2'
 end


### PR DESCRIPTION
Don't see a reason not to do this.