### PR TITLE
allow rails 6.0

### DIFF
--- a/lib/solar_edge/version.rb
+++ b/lib/solar_edge/version.rb
@@ -1,3 +1,3 @@
 module SolarEdge
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/solaredge.gemspec
+++ b/solaredge.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.1'
 
-  s.add_dependency 'activesupport', '~> 5.0'
+  s.add_dependency 'activesupport', '>= 5.0', '< 6.1'
   s.add_development_dependency 'rake', '~> 10.4.2'
 end


### PR DESCRIPTION
Bumps the gemspec to allow AS 6.0.

I tested this in the app console and got the same results as under 5.2.